### PR TITLE
Allow "demo" deploy only if PR comes from the same repo

### DIFF
--- a/.github/workflows/publish-demo-on-pr.yml
+++ b/.github/workflows/publish-demo-on-pr.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   demo:
     runs-on: ubuntu-18.04
+    
+    # Execute only if "base" and "head" repos are the same
+    if: ${{ github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name }}
     steps:
 
       # Configure AWS CLI to access Yandex Cloud


### PR DESCRIPTION
В пулл-реквесте https://github.com/b4ck5p4c3/0x08.in/pull/354 возникла проблема с падающим CI на PR из форков. Это связано с закономерным запретом на доступ к секретам для воркфлоу, триггернутых из форков (https://docs.github.com/en/actions/reference/encrypted-secrets).

Чтобы избежать явного падения воркфлоу, этот пулл-реквест добавляет проверку на совпадение base и head репозиториев. Если они не совпадают — этап деплоя демки пропускается, не выбрасывая ошибку.