### PR TITLE
fix images by reverting Section.Wrapper.Elem from display:flex to block

### DIFF
--- a/src/components/Section/styled.ts
+++ b/src/components/Section/styled.ts
@@ -19,7 +19,6 @@ export const Anchor = styled.a`
 `;
 
 export const Elem = styled.div`
-  display: flex;
   padding: var(--padding-section);
   width: 100%;
 


### PR DESCRIPTION
fixes #352

Картинки сломались в [этот](https://github.com/b4ck5p4c3/0x08.in/commit/02e8dfc49642c2f62bde58837d88ba67f8f3b42a#diff-305db31f558449eaff8925acbec7ca624510e64b4a1835fc8eb20ddf423868e1R36) момент. Не совсем понятно, зачем быдл делать этот блок флексом. Откатил, прокликал все страницы - ничего не ломает, только возвращает картинки обратно.
