### PR TITLE
Images with position:absolute are rendered over the header. Fix it by…

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,6 +10,7 @@ export const Wrapper = styled.header`
   top: 0;
   display: flex;
   position: sticky;
+  z-index: 10;
   justify-content: end;
   flex-direction: column;
   line-height: var(--line-height-header);


### PR DESCRIPTION
… setting z-index to some value

fixes #377